### PR TITLE
Deserialization regular expression parses 'lonely' cookies

### DIFF
--- a/anvil-connect.angular.js
+++ b/anvil-connect.angular.js
@@ -253,7 +253,7 @@ angular.module('anvil', [])
 
         try {
           // Use the cookie value to decrypt the session in localStorage
-          re      = new RegExp('[; ]anvil.connect=([^\\s;]*)');
+          re      = new RegExp('(^|[; ])anvil.connect=([^\\s;]*)');
           secret  = document.cookie.match(re).pop();
           json    = sjcl.decrypt(secret, localStorage['anvil.connect']);
           parsed  = JSON.parse(json);


### PR DESCRIPTION
I noticed my sessions weren't being deserialized on page refreshes. Looking into this it looks like this is caused by the regular expression failing when `anvil.connect` is the only available cookie (and I'm guessing the same holds if it is the first cookie in the store). For me this altered regular expression fixes the issue.